### PR TITLE
chore(DEV-1113): Add GitHub action to validate PR title to meet semantic versioning patterns

### DIFF
--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -1,0 +1,22 @@
+name: PR Title
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+  pull_request_target:
+    branches:
+      - main
+jobs:
+  pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR Title for Semantic Version Key
+        uses: amannn/action-semantic-pull-request@v5
+        timeout-minutes: 5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Summary
===
The semantic versioning relies on the title of the commit to determine
whether the next semantic version release.

This change is intended to solve the problem that `commitlint` attempts
to solve.
Unfortunately, `commitlint` attempts to sanitize commit messages, before
the PR is created or updated.
It doesn't work, and encourages bad patterns and workarounds like
using a nonsensical commit message like:
`fix: Ab cd` or `docs: He ll`

Worse, it doesn't allow us to add useful context like long URLs.
Reference:

https://www.notion.so/0019-Commit-Messages-b7cc6f56354f4f28b902df7cd13b2450

In addition, people don't typically review the commit message, nor
does anyone fix the commit message content. The commit messages remain
uncurated.

In contrast, the PR title and description are read by reviewers, and are
more
likely to be curated.
In addition, since the PR title and description is better curated,
the PR makes sense as the source of truth for the bolus of change.
In other words, it is the best piece of information to drive the commit
log.

Reference:

https://linear.app/clipboardhealth/issue/DEV-1113/add-semantic-version-github-action-to-cbh-core

Changes
===
- Add a github action to check the PR title

Video
---
Tested with invalid prefixes like `shore`, which was caught as invalid.
https://www.loom.com/share/d03f8499171c42c3ad77026637d7ebe0
