### PR TITLE
feat: add org-wide PR title check workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,43 @@
+name: PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      # Nx-generated release PRs keep their `chore(release): ...` title and are exempt.
+      - name: Reject titles with a scope
+        if: ${{ !startsWith(github.event.pull_request.title, 'chore(release):') }}
+        # amannn/action-semantic-pull-request v6.1.1
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Override the default header regex to remove the `(scope)` group entirely,
+          # so any title containing a scope fails to match and is rejected.
+          headerPattern: '^(\w+)(\!)?: (.+)$'
+          headerPatternCorrespondence: type, breaking, subject
+          types: |
+            feat
+            fix
+            chore
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            revert


### PR DESCRIPTION
## Summary

Adds the source workflow for an org-wide PR title check that bans conventional-commit scopes (e.g. `feat(TFR-239): ...`). Once an org ruleset is configured to require this workflow, it enforces the policy across every repo without per-repo workflow files.

Refs [DEVOP-5166](https://linear.app/clipboardhealth/issue/DEVOP-5166/forbid-scopes-in-pr-title-check-across-all-repos).

## Why

Scopes in conventional-commit titles cause `nx release` to skip package version bumps (observed in `clipboard-health` and `open-shifts`). The earlier proposal was to add a `pull-request-title.yml` to every repo. This PR replaces that approach with a single source workflow plus an org ruleset, so the rule lives in one place and cannot drift.

## How it works

- Workflow at `.github/workflows/pr-title.yml`.
- Trigger: `pull_request_target` (`opened`, `edited`, `synchronize`, `reopened`) — runs in the target repo's context with token access, including for forks.
- Validation: overrides `amannn/action-semantic-pull-request`'s `headerPattern` to a regex with no `(scope)` group, so any title containing a scope fails to match and is rejected.
- Carve-out: `chore(release): ...` titles (Nx release PRs) skip the validation step but the job still concludes green — required workflows must conclude with success, not skip.
- Action pinned to SHA `48f25628…` (v6.1.1).

## Manual follow-up (not in this PR)

Wire this up as a required workflow at the org level:

1. Org Settings → Rules → Rulesets → New ruleset (Repository ruleset).
2. Target: all repositories. Branch: default branch.
3. Rule: **Require workflows to pass before merging** → `clipboardhealth/.github` → `.github/workflows/pr-title.yml` pinned to a tag or SHA (not `main`, so a bad commit here cannot break the org).
4. Enforcement: **Active**.

After enforcement is live:
- Validate by opening a test PR with a scoped title in a low-risk repo and confirming the merge button is blocked.
- Delete now-redundant per-repo `pull-request-title.yml` files (clipboard-health, others).
- Close clipboard-health PR #24111 (its goal is subsumed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)